### PR TITLE
fix(Interaction): Excluding children from Interactable Object Grab

### DIFF
--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/GrabAttachMechanics/VRTK_FixedJointGrabAttach.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/GrabAttachMechanics/VRTK_FixedJointGrabAttach.cs
@@ -25,7 +25,8 @@ namespace VRTK.GrabAttachMechanics
 
         protected override void CreateJoint(GameObject obj)
         {
-            givenJoint = obj.AddComponent<FixedJoint>();
+            var rb = obj.GetComponentInParent<Rigidbody>();
++           givenJoint = rb!=null ? rb.gameObject.AddComponent<FixedJoint>() : obj.AddComponent<FixedJoint>();
             givenJoint.breakForce = (grabbedObjectScript.IsDroppable() ? breakForce : Mathf.Infinity);
             base.CreateJoint(obj);
         }

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
@@ -1022,7 +1022,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            interactableRigidbody = GetComponent<Rigidbody>();
+            interactableRigidbody = GetComponentInParent<Rigidbody>();
             if (interactableRigidbody != null)
             {
                 interactableRigidbody.maxAngularVelocity = float.MaxValue;

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
@@ -530,7 +530,7 @@ namespace VRTK
 
         protected virtual void CreateTouchRigidBody()
         {
-            touchRigidBody = (GetComponent<Rigidbody>() != null ? GetComponent<Rigidbody>() : gameObject.AddComponent<Rigidbody>());
+            touchRigidBody = GetComponentInParent<Rigidbody>() != null ? GetComponentInParent<Rigidbody>() : gameObject.AddComponent<Rigidbody>();
             touchRigidBody.isKinematic = true;
             touchRigidBody.useGravity = false;
             touchRigidBody.constraints = RigidbodyConstraints.FreezeAll;


### PR DESCRIPTION
Issue was discussed here: https://github.com/thestonefox/VRTK/issues/870

Proposed fix:
Switch to GetComponentInParent\<Rigidbody\> where it counts