### PR TITLE
feat(Interaction): extension to the VRTK_PolicyList

### DIFF
--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_PolicyList.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_PolicyList.cs
@@ -5,10 +5,10 @@ namespace VRTK
     using System.Collections.Generic;
 
     /// <summary>
-    /// The Policy List allows to create a list of either tag names, script names or layer names that can be checked against to see if another operation is permitted.
+    /// The Policy List allows to create a list of either tag names, script names, layer names or string identifier that can be checked against to see if another operation is permitted.
     /// </summary>
     /// <remarks>
-    /// A number of other scripts can use a Policy List to determine if an operation is permitted based on whether a game object has a tag applied, a script component on it or whether it's on a given layer.
+    /// A number of other scripts can use a Policy List to determine if an operation is permitted based on whether a game object has a tag applied, a script component on it, whether it's on a given layer or whether a game object has the VRTK_PolicyListStringIdentifier component on which a given string is specified on it.
     ///
     /// For example, the Teleporter scripts can ignore game object targets as a teleport location if the game object contains a tag that is in the identifiers list and the policy is set to ignore.
     ///
@@ -52,14 +52,18 @@ namespace VRTK
             /// <summary>
             /// A layer applied to the game object.
             /// </summary>
-            Layer = 4
+            Layer = 4,
+            /// <summary>
+            /// A string is specified in the component VRTK_PolicyListStringIdentifier on the game object.
+            /// </summary>
+            StringIdentifier = 8
         }
 
         [Tooltip("The operation to apply on the list of identifiers.")]
         public OperationTypes operation = OperationTypes.Ignore;
         [Tooltip("The element type on the game object to check against.")]
         public CheckTypes checkType = CheckTypes.Tag;
-        [Tooltip("A list of identifiers to check for against the given check type (either tag or script).")]
+        [Tooltip("A list of identifiers to check for against the given check type (either tag, script or string on game object´s VRTK_PolicyListStringIdentifier component).")]
         public List<string> identifiers = new List<string>() { "" };
 
         /// <summary>
@@ -133,6 +137,20 @@ namespace VRTK
             }
         }
 
+        protected virtual bool StringIdentifierCheck(GameObject obj, bool returnState)
+        {
+            VRTK_PolicyListStringIdentifier stringIdentifier = obj.GetComponent<VRTK_PolicyListStringIdentifier>();
+            
+            if (stringIdentifier != null)
+            {
+                if(stringIdentifier.CheckString(this))
+                {
+                    return returnState;
+                }
+            }
+            return !returnState;
+        }
+
         protected virtual bool TypeCheck(GameObject obj, bool returnState)
         {
             int selection = 0;
@@ -148,6 +166,10 @@ namespace VRTK
             if (((int)checkType & (int)CheckTypes.Layer) != 0)
             {
                 selection += 4;
+            }
+            if (((int)checkType & (int)CheckTypes.StringIdentifier) != 0)
+            {
+                selection += 8;
             }
 
             switch (selection)
@@ -198,6 +220,98 @@ namespace VRTK
                         return returnState;
                     }
                     if ((returnState && LayerCheck(obj, returnState)) || (!returnState && !LayerCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    break;
+                case 8:
+                    return StringIdentifierCheck(obj, returnState);
+                case 9: 
+                    if ((returnState && TagCheck(obj, returnState)) || (!returnState && !TagCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && StringIdentifierCheck(obj, returnState)) || (!returnState && !StringIdentifierCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    break;
+                case 10:
+                    if ((returnState && ScriptCheck(obj, returnState)) || (!returnState && !ScriptCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && StringIdentifierCheck(obj, returnState)) || (!returnState && !StringIdentifierCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    break;
+                case 11:
+                    if ((returnState && TagCheck(obj, returnState)) || (!returnState && !TagCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && ScriptCheck(obj, returnState)) || (!returnState && !ScriptCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && StringIdentifierCheck(obj, returnState)) || (!returnState && !StringIdentifierCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    break;
+                case 12:
+                    if ((returnState && LayerCheck(obj, returnState)) || (!returnState && !LayerCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && StringIdentifierCheck(obj, returnState)) || (!returnState && !StringIdentifierCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    break;
+                case 13:
+                    if ((returnState && TagCheck(obj, returnState)) || (!returnState && !TagCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && LayerCheck(obj, returnState)) || (!returnState && !LayerCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && StringIdentifierCheck(obj, returnState)) || (!returnState && !StringIdentifierCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    break;
+                case 14: 
+                    if ((returnState && ScriptCheck(obj, returnState)) || (!returnState && !ScriptCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && LayerCheck(obj, returnState)) || (!returnState && !LayerCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && StringIdentifierCheck(obj, returnState)) || (!returnState && !StringIdentifierCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    break;
+                case 15: 
+                    if ((returnState && TagCheck(obj, returnState)) || (!returnState && !TagCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && ScriptCheck(obj, returnState)) || (!returnState && !ScriptCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && LayerCheck(obj, returnState)) || (!returnState && !LayerCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && StringIdentifierCheck(obj, returnState)) || (!returnState && !StringIdentifierCheck(obj, returnState)))
                     {
                         return returnState;
                     }

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_PolicyListStringIdentifier.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_PolicyListStringIdentifier.cs
@@ -1,0 +1,36 @@
+﻿// Policy List|Utilities|90071
+namespace VRTK
+{
+    using UnityEngine;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The Policy List String Identifier is the script to specify a string on to be checked against in VRTK_PolicyList to see if another operation is permitted.
+    /// </summary>
+    /// <remarks>
+    /// A number of other scripts can use a Policy List to determine if an operation is permitted based on whether a game object has a tag applied, a script component on it, whether it's on a given layer or whether a game object has the VRTK_PolicyListStringIdentifier component on which a given string is specified on it.    
+    /// If a game object has this component, Policy Lists can check, wheter a string is specified on this game object. 
+    /// Using this script is similar to use identification via game object's tag but has the advantage to keep the tag list clean.
+    /// 
+    /// For example, if you use 100 SnapDropZones (e.g. Keyholes on 100 different locked doors) you would need 100 scripts or 100 different tags and thereby mess up your tag structure or script structure. Using this script you can attach this script to the game object which should be checked and identify a string (e.g. "Key75").
+    /// </remarks>
+    [AddComponentMenu("VRTK/Scripts/Utilities/VRTK_PolicyListStringIdentifier")]
+    public class VRTK_PolicyListStringIdentifier : MonoBehaviour
+    {
+        [Tooltip("This string will be checked against VRTK_PolicyList's identifiers, if VRTK_PolicyList's checkType is set to CheckTypes.StringIdentifier, among others.")]
+        public string stringIdentifier;
+
+        /// <summary>
+        /// This method is called by VRTK_PolicyList's StringIdentifierCheck method to check whether one of it's indentifiers equals the string specified in this' stringIdentifier.
+        /// <param name="obj">This method is called by VRTK_PolicyList's StringIdentifierCheck method and passes itself as parameter.</param>
+        /// <returns>If the string specified in this' stringIdentifier matches the VRTK_PolicyList's identifier list then it returns true.</returns>
+        public virtual bool CheckString(VRTK_PolicyList list)
+        {
+            if (list != null)
+            {
+                return list.identifiers.Contains(stringIdentifier);
+            }
+            return false;
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_PolicyListStringIdentifier.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_PolicyListStringIdentifier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d654cc8f7e63c1d479c518f9179e784f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: e9f457e274df65d44bab585d6d39b017, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds the stringIdentifier option to VRTK_PolicyList
(see #1698).
Allows user to specify a string on any game object.
This string will be checked against any
VRTK_PolicyList's identifiers to determine, whether
two objects should interact.