### PR TITLE
fix(OculusHeadset): include latest GearVR and Oculus Go revisions

### DIFF
--- a/Assets/VRTK/Source/SDK/Oculus/SDK_OculusHeadset.cs
+++ b/Assets/VRTK/Source/SDK/Oculus/SDK_OculusHeadset.cs
@@ -79,6 +79,9 @@ namespace VRTK
                 case OVRPlugin.SystemHeadset.GearVR_R321:
                 case OVRPlugin.SystemHeadset.GearVR_R322:
                 case OVRPlugin.SystemHeadset.GearVR_R323:
+                case OVRPlugin.SystemHeadset.GearVR_R324:
+                case OVRPlugin.SystemHeadset.GearVR_R325:
+                case OVRPlugin.SystemHeadset.Oculus_Go:
                     return CleanPropertyString("oculusgearvr");
                 case OVRPlugin.SystemHeadset.Rift_DK1:
                     return CleanPropertyString("oculusriftdk1");


### PR DESCRIPTION
Re-doing PR per request on https://github.com/thestonefox/VRTK/pull/1781 with latest GearVR and Oculus Go headset identifiers.
