### PR TITLE
fix(Controller): fix thumbstick axis movement on Oculus Touch

### DIFF
--- a/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRController.cs
@@ -472,7 +472,7 @@ namespace VRTK
         /// <returns>Returns true if the touchpad is not currently being touched or moved.</returns>
         public override bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity)
         {
-            return (!isTouched || VRTK_SharedMethods.Vector2ShallowCompare(currentAxisValues, previousAxisValues, compareFidelity));
+            return ((!isTouched && GetCurrentControllerType() != ControllerType.SteamVR_OculusTouch) || VRTK_SharedMethods.Vector2ShallowCompare(currentAxisValues, previousAxisValues, compareFidelity));
         }
 
         /// <summary>


### PR DESCRIPTION
Allow to detect thumbstick movement on Oculus Touch when sensitive pad at the top is not
touched and SteamVR backend is used.
The problem was described and solved for Oculus SDK in this commit https://github.com/thestonefox/VRTK/commit/b213073daec55c4a98f947d5fab11416ec492908 . 
But it was fixed only for OculusSDK + Oculus and not for SteamVR + Oculus. 