### PR TITLE
fix(SDKSetup): don't try to fix open but unloaded scenes

### DIFF
--- a/Assets/VRTK/Source/Editor/VRTK_SDKSetupEditor.cs
+++ b/Assets/VRTK/Source/Editor/VRTK_SDKSetupEditor.cs
@@ -440,9 +440,10 @@
 
             private static void FixOpenAndUnsavedScenes()
             {
-
                 List<VRTK_SDKSetup> setups = Enumerable.Range(0, EditorSceneManager.loadedSceneCount)
-                                                       .SelectMany(sceneIndex => SceneManager.GetSceneAt(sceneIndex).GetRootGameObjects())
+                                                       .Select(sceneIndex => SceneManager.GetSceneAt(sceneIndex))
+                                                       .Where(scene => scene.isLoaded)
+                                                       .SelectMany(scene => scene.GetRootGameObjects())
                                                        .SelectMany(rootObject => rootObject.GetComponentsInChildren<VRTK_SDKManager>())
                                                        .Select(manager => manager.setups.Where(setup => setup != null).ToArray())
                                                        .Where(sdkSetups => sdkSetups.Length > 1)


### PR DESCRIPTION
This is related to #1889.

The same problem happens in SDKSetupEditor, but I had Clear on Play enabled and the error was removed from the console before I saw it.