### PR TITLE
fix(Interaction): Flag controllerAttachPoint externally set

### DIFF
--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractGrab.cs
@@ -74,6 +74,12 @@ namespace VRTK
         /// </summary>
         public event ObjectInteractEventHandler ControllerUngrabInteractableObject;
 
+        /// <summary>
+        /// Whether the attach point has been set externally, e.g. by the pointer renderer when the pointer grabs to its tip.
+        /// </summary>
+        [HideInInspector]
+        public bool controllerAttachPointExternallySet = false;
+
         protected VRTK_ControllerEvents.ButtonAlias subscribedGrabButton = VRTK_ControllerEvents.ButtonAlias.Undefined;
         protected VRTK_ControllerEvents.ButtonAlias savedGrabButton = VRTK_ControllerEvents.ButtonAlias.Undefined;
         protected bool grabPressed;
@@ -184,6 +190,7 @@ namespace VRTK
         {
             originalControllerAttachPoint = forcedAttachPoint;
             controllerAttachPoint = forcedAttachPoint;
+            controllerAttachPointExternallySet = true;
         }
 
         protected virtual void Awake()
@@ -340,7 +347,7 @@ namespace VRTK
         protected virtual void SetControllerAttachPoint()
         {
             //If no attach point has been specified then just use the tip of the controller
-            if (controllerReference.model != null && originalControllerAttachPoint == null)
+            if (controllerReference.model != null && originalControllerAttachPoint == null && !controllerAttachPointExternallySet)
             {
                 //attempt to find the attach point on the controller
                 SDK_BaseController.ControllerHand handType = VRTK_DeviceFinder.GetControllerHand(interactTouch.gameObject);

--- a/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -332,6 +332,7 @@ namespace VRTK
                 {
                     savedAttachPoint = controllerGrabScript.controllerAttachPoint;
                     controllerGrabScript.controllerAttachPoint = objectInteractorAttachPoint.GetComponent<Rigidbody>();
+                    controllerGrabScript.controllerAttachPointExternallySet = true;
                     attachedToInteractorAttachPoint = true;
                 }
 
@@ -345,6 +346,7 @@ namespace VRTK
                     if (savedAttachPoint != null)
                     {
                         controllerGrabScript.controllerAttachPoint = savedAttachPoint;
+                        controllerGrabScript.controllerAttachPointExternallySet = true;
                         savedAttachPoint = null;
                     }
                     attachedToInteractorAttachPoint = false;


### PR DESCRIPTION
When a `VRTK_Pointer` has both `Activate on Enable` and `Grab To Pointer Tip` checked, when the game runs, the grabbing is made with the controller itself, not the pointer tip. The tip grabs only after deactivating and reactivating the pointer.

The reason is: `VRTK_BasePointerRenderer` sets the `controllerAttachPoint` to the tip, and just after `VRTK_InteractGrab` resets it to the default attach point, on the controller.

This patch adds a bool to flag whether `controllerAttachPoint` has been set by `VRTK_BasePointerRenderer`.