### PR TITLE
fix(Interaction): Some minor interaction fixes

### DIFF
--- a/Assets/VRTK/Prefabs/SnapDropZone/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/SnapDropZone/VRTK_SnapDropZone.cs
@@ -460,7 +460,18 @@ namespace VRTK
 
         protected virtual void OnTriggerExit(Collider collider)
         {
-            CheckCanUnsnap(collider.GetComponentInParent<VRTK_InteractableObject>());
+            bool isKinematic = collider.attachedRigidbody != null && collider.attachedRigidbody.isKinematic;
+            var interactable = collider.GetComponentInParent<VRTK_InteractableObject>();
+
+            // Kinematic objects should only leave their drop zone if they are grabbed and pulled out. 
+            // What can happen otherwise is that a kinematic rb may not follow its parent non kinematic
+            // object in time and thus generate a OnTriggerExit
+            if (isKinematic && interactable != null)
+            {
+                if (!interactable.IsGrabbed())
+                    return;
+            }
+            CheckCanUnsnap(interactable);
         }
 
         protected virtual void CheckCanSnap(VRTK_InteractableObject interactableObjectCheck)

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/GrabAttachMechanics/VRTK_CustomJointGrabAttach.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/GrabAttachMechanics/VRTK_CustomJointGrabAttach.cs
@@ -50,7 +50,7 @@ namespace VRTK.GrabAttachMechanics
 
         protected override void DestroyJoint(bool withDestroyImmediate, bool applyGrabbingObjectVelocity)
         {
-            base.DestroyJoint(true, true);
+            base.DestroyJoint(withDestroyImmediate, true);
         }
 
         protected virtual void CopyCustomJoint()

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
@@ -1443,11 +1443,7 @@ namespace VRTK
                     LoadPreviousState();
                     break;
                 case VRTK_SnapDropZone.SnapTypes.UseJoint:
-                    Joint snapDropZoneJoint = storedSnapDropZone.GetComponent<Joint>();
-                    if (snapDropZoneJoint)
-                    {
-                        snapDropZoneJoint.connectedBody = null;
-                    }
+                    storedSnapDropZone.UnSnapJoint();
                     break;
             }
 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
@@ -534,7 +534,7 @@ namespace VRTK
             touchRigidBody.isKinematic = true;
             touchRigidBody.useGravity = false;
             touchRigidBody.constraints = RigidbodyConstraints.FreezeAll;
-            touchRigidBody.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+            touchRigidBody.collisionDetectionMode = CollisionDetectionMode.Discrete;
         }
 
         protected virtual void EmitControllerRigidbodyEvent(bool state)


### PR DESCRIPTION
Issues:
- Grab attach did not work when parent was moving
- DestroyImmediate call cause issues when using 
grabmechanics and dropping due to large force
- 2018.3 does not allow CCD on static rigidbody