### PR TITLE
Update VRTK_ArtificialPusher.cs

### DIFF
--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Artificial/VRTK_ArtificialPusher.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Artificial/VRTK_ArtificialPusher.cs
@@ -148,24 +148,20 @@ namespace VRTK.Controllables.ArtificialBased
                 atMaxLimit = true;
                 OnMaxLimitReached(payload);
             }
-            else if (currentPosition <= minThreshold && !AtMinLimit())
+            else if (currentPosition < maxThreshold && AtMaxLimit())
+            {
+                atMaxLimit = false;
+                OnMaxLimitExited(payload);
+            }
+            if (currentPosition <= minThreshold && !AtMinLimit())
             {
                 atMinLimit = true;
                 OnMinLimitReached(payload);
             }
-            else if (currentPosition > minThreshold && currentPosition < maxThreshold)
+            else if (currentPosition > minThreshold && AtMinLimit())
             {
-                if (AtMinLimit())
-                {
-                    OnMinLimitExited(payload);
-                }
-                if (AtMaxLimit())
-                {
-                    OnMaxLimitExited(payload);
-                }
-
                 atMinLimit = false;
-                atMaxLimit = false;
+                OnMinLimitExited(payload);
             }
 
             if (IsResting())


### PR DESCRIPTION
In some case (like framedrop) update wasn't correct and result in cases where atMinLimit and atMaxLimit was both true