### PR TITLE
feat(Prefabs): add SnapDropZone prefab - resolves ExtendRealityLtd/Zinnia.Unity#56

### DIFF
--- a/Prefabs/Interactions/SnapDropZone.meta
+++ b/Prefabs/Interactions/SnapDropZone.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cffb4e089ea46c44ca23747d43f952f3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Interactions/SnapDropZone/SharedResources.meta
+++ b/Prefabs/Interactions/SnapDropZone/SharedResources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ccdd9ca12ee337642aeeef735c498f87
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts.meta
+++ b/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d55535a931c4eb4b90bd0b8ac25586d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/InteractableEventForwarder.cs
+++ b/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/InteractableEventForwarder.cs
@@ -1,0 +1,99 @@
+﻿namespace VRTK.Prefabs.Interactions.SnapDropZone
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+    using System.Collections.Generic;
+    using Malimbe.BehaviourStateRequirementMethod;
+    using Malimbe.XmlDocumentationAttribute;
+    using VRTK.Prefabs.Interactions.Interactables;
+    using VRTK.Prefabs.Interactions.Interactors;
+    using Zinnia.Extension;
+
+    /// <summary>
+    /// Emits events when the same event on an observed <see cref="InteractableFacade"/> is raised.
+    /// </summary>
+    public class InteractableEventForwarder : MonoBehaviour
+    {
+        /// <summary>
+        /// Defines the event with the specified <see cref="GameObject"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<GameObject>
+        {
+        }
+
+        /// <summary>
+        /// Emitted when an added object has no <see cref="InteractableFacade"/> on it.
+        /// </summary>
+        [DocumentedByXml]
+        public UnityEvent NotInteractable = new UnityEvent();
+        /// <summary>
+        /// Emitted when an <see cref="InteractableFacade"/> is grabbed.
+        /// </summary>
+        [DocumentedByXml]
+        public UnityEvent Grabbed = new UnityEvent();
+        /// <summary>
+        /// Emitted when an <see cref="InteractableFacade"/> is ungrabbed.
+        /// </summary>
+        [DocumentedByXml]
+        public UnityEvent Ungrabbed = new UnityEvent();
+
+        /// <summary>
+        /// <see cref="Action"/>s that unsubscribe the added event listeners.
+        /// </summary>
+        protected readonly Dictionary<InteractableFacade, Action> unsubscribeActions = new Dictionary<InteractableFacade, Action>();
+
+        /// <summary>
+        /// Starts observing events on the given <see cref="InteractableFacade"/> or immediately raises <see cref="NotInteractable"/>.
+        /// </summary>
+        /// <param name="gameObject">The object potentially having a <see cref="InteractableFacade"/>.</param>
+        [RequiresBehaviourState]
+        public virtual void Add(GameObject gameObject)
+        {
+            InteractableFacade interactableFacade = gameObject.TryGetComponent<InteractableFacade>(true, true);
+            if (interactableFacade != null)
+            {
+                gameObject = interactableFacade.gameObject;
+            }
+
+            if (interactableFacade == null || interactableFacade.GrabbingInteractors.Count == 0)
+            {
+                NotInteractable?.Invoke(gameObject);
+                return;
+            }
+
+            void OnGrabbed(InteractorFacade _) =>
+                Grabbed?.Invoke(gameObject);
+
+            void OnUngrabbed(InteractorFacade _) =>
+                Ungrabbed?.Invoke(gameObject);
+
+            interactableFacade.Grabbed.AddListener(OnGrabbed);
+            interactableFacade.Ungrabbed.AddListener(OnUngrabbed);
+
+            unsubscribeActions[interactableFacade] = () =>
+            {
+                interactableFacade.Ungrabbed.RemoveListener(OnUngrabbed);
+                interactableFacade.Grabbed.RemoveListener(OnGrabbed);
+            };
+        }
+
+        /// <summary>
+        /// Stops observing events on the given <see cref="GameObject"/>.
+        /// </summary>
+        /// <param name="gameObject">The object potentially having a <see cref="InteractableFacade"/>.</param>
+        [RequiresBehaviourState]
+        public virtual void Remove(GameObject gameObject)
+        {
+            InteractableFacade interactableFacade = gameObject.TryGetComponent<InteractableFacade>(true, true);
+            if (interactableFacade == null
+                || !unsubscribeActions.TryGetValue(interactableFacade, out Action unsubscribeAction))
+            {
+                return;
+            }
+
+            unsubscribeAction();
+        }
+    }
+}

--- a/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/InteractableEventForwarder.cs.meta
+++ b/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/InteractableEventForwarder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5229671ff125455297a016f0562d77c2
+timeCreated: 1550329800

--- a/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/RigidbodyKinematicMutator.cs
+++ b/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/RigidbodyKinematicMutator.cs
@@ -1,0 +1,83 @@
+﻿namespace VRTK.Prefabs.Interactions.SnapDropZone
+{
+    using UnityEngine;
+    using Malimbe.MemberClearanceMethod;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.PropertySetterMethod;
+    using Malimbe.PropertyValidationMethod;
+    using Malimbe.XmlDocumentationAttribute;
+
+    /// <summary>
+    /// Enables and disables an object's <see cref="Rigidbody.isKinematic"/> state.
+    /// </summary>
+    public class RigidbodyKinematicMutator : MonoBehaviour
+    {
+        /// <summary>
+        /// The <see cref="Rigidbody"/> to change the kinematic state on.
+        /// </summary>
+        [Serialized, Validated, Cleared]
+        [field: DocumentedByXml]
+        public Rigidbody Target { get; set; }
+        /// <summary>
+        /// Whether <see cref="Target"/> should be kinematic.
+        /// </summary>
+        [Serialized, Validated]
+        [field: DocumentedByXml]
+        public bool IsKinematic { get; set; }
+        /// <summary>
+        /// Whether to restore the kinematic state of the previous <see cref="Target"/> whenever it changes.
+        /// </summary>
+        [Serialized, Validated]
+        [field: DocumentedByXml]
+        public bool RestoresPreviousKinematicState { get; set; } = true;
+
+        /// <summary>
+        /// Whether <see cref="Target"/> was kinematic before changing the kinematic state.
+        /// </summary>
+        protected bool? wasKinematic;
+
+        /// <summary>
+        /// Handles changes to <see cref="Target"/>.
+        /// </summary>
+        /// <param name="previousValue">The previous value.</param>
+        /// <param name="newValue">The new value.</param>
+        [CalledBySetter(nameof(Target))]
+        public virtual void OnTargetChange(Rigidbody previousValue, ref Rigidbody newValue)
+        {
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+
+            if (previousValue != null && RestoresPreviousKinematicState && wasKinematic != null)
+            {
+                previousValue.isKinematic = wasKinematic.Value;
+            }
+
+            if (newValue == null)
+            {
+                wasKinematic = null;
+                return;
+            }
+
+            wasKinematic = newValue.isKinematic;
+            newValue.isKinematic = IsKinematic;
+        }
+
+        /// <summary>
+        /// Handles changes to <see cref="IsKinematic"/>.
+        /// </summary>
+        /// <param name="previousValue">The previous value.</param>
+        /// <param name="newValue">The new value.</param>
+        [CalledBySetter(nameof(IsKinematic))]
+        public virtual void OnIsKinematicChange(bool previousValue, ref bool newValue)
+        {
+            if (!Application.isPlaying || Target == null)
+            {
+                return;
+            }
+
+            Target.isKinematic = newValue;
+        }
+    }
+}

--- a/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/RigidbodyKinematicMutator.cs.meta
+++ b/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/RigidbodyKinematicMutator.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 11ed1816c5dc4511a52b7c381fcc5a92
+timeCreated: 1550500800

--- a/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/SnapDropZoneFacade.cs
+++ b/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/SnapDropZoneFacade.cs
@@ -1,0 +1,129 @@
+﻿namespace VRTK.Prefabs.Interactions.SnapDropZone
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+    using Malimbe.MemberClearanceMethod;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.PropertySetterMethod;
+    using Malimbe.PropertyValidationMethod;
+    using Malimbe.XmlDocumentationAttribute;
+    using Zinnia.Data.Attribute;
+
+    /// <summary>
+    /// The public interface into the SnapDropZone prefab.
+    /// </summary>
+    public class SnapDropZoneFacade : MonoBehaviour
+    {
+        /// <summary>
+        /// Defines the event with the specified <see cref="GameObject"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<GameObject>
+        {
+        }
+
+        #region SnapDropZone Settings
+        /// <summary>
+        /// The currently snapped object.
+        /// </summary>
+        [Serialized, Validated, Cleared]
+        [field: Header("SnapDropZone Settings"), DocumentedByXml]
+        public GameObject SnappedObject { get; set; }
+        /// <summary>
+        /// Whether to clone <see cref="SnappedObject"/> on raise of <see cref="Unsnapped"/>.
+        /// </summary>
+        [Serialized, Validated]
+        [field: DocumentedByXml]
+        public bool ClonesOnUnsnap { get; set; }
+        #endregion
+
+        #region SnapDropZone Events
+        /// <summary>
+        /// Emitted when <see cref="SnappedObject"/> changes to another (non-<see langword="null"/>) <see cref="GameObject"/>.
+        /// </summary>
+        [Header("SnapDropZone Events"), DocumentedByXml]
+        public UnityEvent Snapped = new UnityEvent();
+        /// <summary>
+        /// Emitted when <see cref="SnappedObject"/> changes to <see langword="null"/>.
+        /// </summary>
+        [DocumentedByXml]
+        public UnityEvent Unsnapped = new UnityEvent();
+        #endregion
+
+        #region Internal Settings
+        /// <summary>
+        /// The linked <see cref="SnapDropZoneInternalSetup"/>.
+        /// </summary>
+        [Serialized, Validated, Cleared]
+        [field: Header("Internal Settings"), DocumentedByXml, InternalSetting]
+        public SnapDropZoneInternalSetup InternalSetup { get; set; }
+        #endregion
+
+        /// <summary>
+        /// Sets <see cref="SnappedObject"/> to the given <see cref="GameObject"/> if there currently is no snapped object.
+        /// </summary>
+        /// <param name="snappedObject">The object to snap.</param>
+        public virtual void SetSnappedObjectIfEmpty(GameObject snappedObject)
+        {
+            if (SnappedObject == null)
+            {
+                SnappedObject = snappedObject;
+            }
+        }
+
+        /// <summary>
+        /// Clears <see cref="SnappedObject"/> if the given object is equal to it.
+        /// </summary>
+        /// <param name="snappedObject">The object to unsnap.</param>
+        public virtual void ClearSnappedObjectIfEqual(GameObject snappedObject)
+        {
+            if (SnappedObject == snappedObject)
+            {
+                SnappedObject = null;
+            }
+        }
+
+        /// <summary>
+        /// Handles changes to <see cref="SnappedObject"/>.
+        /// </summary>
+        /// <param name="previousValue">The previous value.</param>
+        /// <param name="newValue">The new value.</param>
+        [CalledBySetter(nameof(SnappedObject))]
+        protected virtual void OnSnappedObjectChange(GameObject previousValue, ref GameObject newValue)
+        {
+            if (!Application.isPlaying || InternalSetup == null)
+            {
+                return;
+            }
+
+            if (previousValue != null && previousValue != newValue)
+            {
+                Unsnapped?.Invoke(previousValue);
+            }
+
+            InternalSetup.ConfigureForSnappedObject(newValue);
+
+            if (newValue != null && previousValue != newValue)
+            {
+                Snapped?.Invoke(newValue);
+            }
+        }
+
+        /// <summary>
+        /// Handles changes to <see cref="ClonesOnUnsnap"/>.
+        /// </summary>
+        /// <param name="previousValue">The previous value.</param>
+        /// <param name="newValue">The new value.</param>
+        [CalledBySetter(nameof(ClonesOnUnsnap))]
+        protected virtual void OnClonesOnUnsnapChange(bool previousValue, ref bool newValue)
+        {
+            if (!Application.isPlaying || InternalSetup == null)
+            {
+                return;
+            }
+
+            InternalSetup.ConfigureCloning(newValue);
+        }
+    }
+}

--- a/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/SnapDropZoneFacade.cs.meta
+++ b/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/SnapDropZoneFacade.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4cbd3bff94e89b046bac4c364f96fca4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/SnapDropZoneInternalSetup.cs
+++ b/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/SnapDropZoneInternalSetup.cs
@@ -1,0 +1,179 @@
+﻿namespace VRTK.Prefabs.Interactions.SnapDropZone
+{
+    using UnityEngine;
+    using Malimbe.MemberClearanceMethod;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.PropertyValidationMethod;
+    using Malimbe.XmlDocumentationAttribute;
+    using Zinnia.Data.Attribute;
+    using Zinnia.Data.Operation;
+    using Zinnia.Tracking.Collision;
+    using Zinnia.Tracking.Follow;
+    using Zinnia.Tracking.Modification;
+
+    /// <summary>
+    /// Sets up the SnapDropZone prefab based on the provided user settings.
+    /// </summary>
+    public class SnapDropZoneInternalSetup : MonoBehaviour
+    {
+        #region Facade Settings
+        /// <summary>
+        /// The public interface facade.
+        /// </summary>
+        [Serialized, Validated, Cleared]
+        [field: Header("Facade Settings"), InternalSetting, DocumentedByXml]
+        public SnapDropZoneFacade Facade { get; private set; }
+        #endregion
+
+        #region Reference Settings
+        /// <summary>
+        /// Tracks objects entering and exiting the <see cref="SnapDropZoneFacade"/>.
+        /// </summary>
+        [Serialized, Validated, Cleared]
+        [field: Header("Reference Settings"), InternalSetting, DocumentedByXml]
+        public CollisionTracker CollisionTracker { get; private set; }
+        /// <summary>
+        /// Enables and disables snapped and unsnapped objects' <see cref="Rigidbody.isKinematic"/> state.
+        /// </summary>
+        [Serialized, Validated, Cleared]
+        [field: InternalSetting, DocumentedByXml]
+        public RigidbodyKinematicMutator RigidbodyKinematicMutator { get; private set; }
+        /// <summary>
+        /// Lerps <see cref="SnapDropZoneFacade.SnappedObject"/> to the configured target transform state.
+        /// </summary>
+        [Serialized, Validated, Cleared]
+        [field: InternalSetting, DocumentedByXml]
+        public TransformPropertyApplier Lerper { get; private set; }
+        /// <summary>
+        /// Ensures <see cref="SnapDropZoneFacade.SnappedObject"/> follows the <see cref="SnapDropZoneFacade"/>.
+        /// </summary>
+        [Serialized, Validated, Cleared]
+        [field: InternalSetting, DocumentedByXml]
+        public ObjectFollower ObjectFollower { get; private set; }
+        /// <summary>
+        /// Duplicates <see cref="SnapDropZoneFacade.SnappedObject"/> on raise of <see cref="SnapDropZoneFacade.Unsnapped"/>.
+        /// </summary>
+        [Serialized, Validated, Cleared]
+        [field: InternalSetting, DocumentedByXml]
+        public GameObjectCloner Cloner { get; private set; }
+        #endregion
+
+        /// <summary>
+        /// Configures the internal setup for the snapped object.
+        /// </summary>
+        /// <param name="snappedObject">The snapped object.</param>
+        public virtual void ConfigureForSnappedObject(GameObject snappedObject)
+        {
+            ConfigureCollisionTracker(snappedObject);
+            ConfigureLerp(snappedObject);
+            ConfigureFollow(snappedObject);
+        }
+
+        /// <summary>
+        /// Configures <see cref="Cloner"/>.
+        /// </summary>
+        /// <param name="clonesOnUnsnap">Whether to clone the snapped object on raise of <see cref="SnapDropZoneFacade.Unsnapped"/>.</param>
+        public virtual void ConfigureCloning(bool clonesOnUnsnap)
+        {
+            Cloner.enabled = clonesOnUnsnap;
+        }
+
+        protected virtual void OnEnable()
+        {
+            Cloner.enabled = Facade.ClonesOnUnsnap;
+            Facade.Snapped.AddListener(OnSnapped);
+            Facade.Unsnapped.AddListener(OnUnsnapped);
+        }
+
+        protected virtual void OnDisable()
+        {
+            Facade.Unsnapped.RemoveListener(OnUnsnapped);
+            Facade.Snapped.RemoveListener(OnSnapped);
+        }
+
+        /// <summary>
+        /// Handles an object getting snapped by <see cref="Facade"/>.
+        /// </summary>
+        /// <param name="snappedObject">The snapped object.</param>
+        protected virtual void OnSnapped(GameObject snappedObject)
+        {
+            Rigidbody snappedRigidbody = snappedObject.GetComponent<Rigidbody>();
+            if (snappedRigidbody != null)
+            {
+                RigidbodyKinematicMutator.Target = snappedRigidbody;
+            }
+        }
+
+        /// <summary>
+        /// Handles an object getting unsnapped from <see cref="Facade"/>.
+        /// </summary>
+        /// <param name="unsnappedObject">The unsnapped object.</param>
+        protected virtual void OnUnsnapped(GameObject unsnappedObject)
+        {
+            if (RigidbodyKinematicMutator != null)
+            {
+                RigidbodyKinematicMutator.Target = null;
+            }
+
+            if (Cloner == null)
+            {
+                return;
+            }
+
+            GameObject clone = Cloner.Clone(unsnappedObject);
+            if (clone != null && RigidbodyKinematicMutator != null)
+            {
+                RigidbodyKinematicMutator.Target = clone.GetComponent<Rigidbody>();
+            }
+        }
+
+        /// <summary>
+        /// Configures <see cref="CollisionTracker"/>.
+        /// </summary>
+        /// <param name="snappedObject">The snapped object.</param>
+        protected virtual void ConfigureCollisionTracker(GameObject snappedObject)
+        {
+            if (CollisionTracker == null)
+            {
+                return;
+            }
+
+            CollisionTracker.enabled = snappedObject == null;
+        }
+
+        /// <summary>
+        /// Configures <see cref="Lerper"/>.
+        /// </summary>
+        /// <param name="snappedObject">The snapped object.</param>
+        protected virtual void ConfigureLerp(GameObject snappedObject)
+        {
+            if (Lerper == null)
+            {
+                return;
+            }
+
+            Lerper.enabled = false;
+            Lerper.Target = snappedObject == null ? null : snappedObject;
+            Lerper.enabled = true;
+            Lerper.Apply();
+        }
+
+        /// <summary>
+        /// Configures <see cref="ObjectFollower"/>.
+        /// </summary>
+        /// <param name="snappedObject">The snapped object.</param>
+        protected virtual void ConfigureFollow(GameObject snappedObject)
+        {
+            if (ObjectFollower == null)
+            {
+                return;
+            }
+
+            ObjectFollower.ClearTargets();
+            if (snappedObject != null)
+            {
+                ObjectFollower.AddTarget(snappedObject);
+            }
+        }
+    }
+}

--- a/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/SnapDropZoneInternalSetup.cs.meta
+++ b/Prefabs/Interactions/SnapDropZone/SharedResources/Scripts/SnapDropZoneInternalSetup.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4d9a6f7c1d4d4b78a311230cdcdabb77
+timeCreated: 1550397006

--- a/Prefabs/Interactions/SnapDropZone/SnapDropZone.prefab
+++ b/Prefabs/Interactions/SnapDropZone/SnapDropZone.prefab
@@ -1,0 +1,885 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5154085911745342996
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7295044457275428506}
+  - component: {fileID: 2414807531564309477}
+  m_Layer: 0
+  m_Name: SetKinematic
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7295044457275428506
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5154085911745342996}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6431296929074298364}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2414807531564309477
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5154085911745342996}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 11ed1816c5dc4511a52b7c381fcc5a92, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 0}
+  isKinematic: 1
+  restoresPreviousKinematicState: 1
+--- !u!1 &6431296929040639169
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6431296929040639168}
+  - component: {fileID: 6431296929040639171}
+  m_Layer: 0
+  m_Name: SnapDropZone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6431296929040639168
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296929040639169}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6431296930874057621}
+  - {fileID: 6431296930386113178}
+  - {fileID: 6431296929051571372}
+  - {fileID: 6431296929074298364}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6431296929040639171
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296929040639169}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4cbd3bff94e89b046bac4c364f96fca4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  snappedObject: {fileID: 0}
+  clonesOnUnsnap: 0
+  Snapped:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: VRTK.Prefabs.Interactions.SnapDropZone.SnapDropZoneFacade+UnityEvent,
+      VRTK.Prefabs.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Unsnapped:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: VRTK.Prefabs.Interactions.SnapDropZone.SnapDropZoneFacade+UnityEvent,
+      VRTK.Prefabs.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  internalSetup: {fileID: 6431296929074298367}
+--- !u!1 &6431296929051571373
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6431296929051571372}
+  m_Layer: 0
+  m_Name: SnapMethods
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6431296929051571372
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296929051571373}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6431296929333750247}
+  - {fileID: 6435950448995388925}
+  m_Father: {fileID: 6431296929040639168}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6431296929074298365
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6431296929074298364}
+  - component: {fileID: 6431296929074298367}
+  m_Layer: 0
+  m_Name: Internal
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6431296929074298364
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296929074298365}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6431296930440154727}
+  - {fileID: 7295044457275428506}
+  - {fileID: 6431296929229523180}
+  - {fileID: 6431296930356037162}
+  m_Father: {fileID: 6431296929040639168}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6431296929074298367
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296929074298365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d9a6f7c1d4d4b78a311230cdcdabb77, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  facade: {fileID: 6431296929040639171}
+  collisionTracker: {fileID: 6431296930874057623}
+  rigidbodyKinematicMutator: {fileID: 2414807531564309477}
+  lerper: {fileID: 6431296929333750246}
+  objectFollower: {fileID: 6402115879936492683}
+  cloner: {fileID: 6431296930356037173}
+--- !u!1 &6431296929229523181
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6431296929229523180}
+  - component: {fileID: 6431296929229523183}
+  m_Layer: 0
+  m_Name: DeferSnapIfInteractable
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6431296929229523180
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296929229523181}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6431296929074298364}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6431296929229523183
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296929229523181}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5229671ff125455297a016f0562d77c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NotInteractable:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6431296929040639171}
+        m_MethodName: SetSnappedObjectIfEmpty
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: VRTK.Prefabs.Interactions.SnapDropZone.InteractableEventForwarder+UnityEvent,
+      VRTK.Prefabs.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Grabbed:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6431296929040639171}
+        m_MethodName: ClearSnappedObjectIfEqual
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: VRTK.Prefabs.Interactions.SnapDropZone.InteractableEventForwarder+UnityEvent,
+      VRTK.Prefabs.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Ungrabbed:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6431296929040639171}
+        m_MethodName: SetSnappedObjectIfEmpty
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: VRTK.Prefabs.Interactions.SnapDropZone.InteractableEventForwarder+UnityEvent,
+      VRTK.Prefabs.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+--- !u!1 &6431296929333750244
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6431296929333750247}
+  - component: {fileID: 6431296929333750246}
+  m_Layer: 0
+  m_Name: Lerp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6431296929333750247
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296929333750244}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6431296929051571372}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6431296929333750246
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296929333750244}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2dec536a0cacdc84b84a384ca98d6493, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    transform: {fileID: 6431296930386113178}
+  target: {fileID: 0}
+  offset: {fileID: 0}
+  applyPositionOffsetOnAxis:
+    xState: 1
+    yState: 1
+    zState: 1
+  applyRotationOffsetOnAxis:
+    xState: 1
+    yState: 1
+    zState: 1
+  applyTransformations: -1
+  transitionDuration: 1
+  transitionDestinationThreshold: 0.01
+  BeforeTransformUpdated:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Tracking.Modification.TransformPropertyApplier+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  AfterTransformUpdated:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Tracking.Modification.TransformPropertyApplier+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+--- !u!1 &6431296930356037163
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6431296930356037162}
+  - component: {fileID: 6431296930356037173}
+  m_Layer: 0
+  m_Name: CloneOnUnsnap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6431296930356037162
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930356037163}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6431296929074298364}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6431296930356037173
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930356037163}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a7cb0e1c66ee4bdc91473bed747606b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 0}
+  parent: {fileID: 0}
+  Cloned:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6431296929040639171}
+        m_MethodName: SetSnappedObjectIfEmpty
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: Zinnia.Data.Operation.GameObjectCloner+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+--- !u!1 &6431296930386113179
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6431296930386113178}
+  m_Layer: 0
+  m_Name: SnapTargetState
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6431296930386113178
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930386113179}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6431296929040639168}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6431296930440154724
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6431296930440154727}
+  m_Layer: 0
+  m_Name: HandleCollisions
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6431296930440154727
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930440154724}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6431296930856741453}
+  - {fileID: 6431296930578707288}
+  m_Father: {fileID: 6431296929074298364}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6431296930578707289
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6431296930578707288}
+  - component: {fileID: 6431296930578707291}
+  m_Layer: 0
+  m_Name: CollisionStopped
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6431296930578707288
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930578707289}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6431296930440154727}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6431296930578707291
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930578707289}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ba768ecdd7b4b2e99b76e6ee4960c23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Extracted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6431296929229523183}
+        m_MethodName: Remove
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 6431296929040639171}
+        m_MethodName: ClearSnappedObjectIfEqual
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: Zinnia.Event.GameObjectEmitter+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!1 &6431296930856741442
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6431296930856741453}
+  - component: {fileID: 6431296930856741452}
+  m_Layer: 0
+  m_Name: CollisionStarted
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6431296930856741453
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930856741442}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6431296930440154727}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6431296930856741452
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930856741442}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ba768ecdd7b4b2e99b76e6ee4960c23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Extracted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6431296929229523183}
+        m_MethodName: Add
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: Zinnia.Event.GameObjectEmitter+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!1 &6431296930874057610
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6431296930874057621}
+  - component: {fileID: 6431296930874057623}
+  - component: {fileID: 6431296930874057620}
+  m_Layer: 0
+  m_Name: ColliderContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6431296930874057621
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930874057610}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6431296930920124866}
+  m_Father: {fileID: 6431296929040639168}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6431296930874057623
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930874057610}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b20687ab7424fdb9831faad0eef53ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  emittedTypes: -1
+  forwardingSourceValidity:
+    field: {fileID: 0}
+  CollisionStarted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6431296930856741452}
+        m_MethodName: DoExtract
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: Zinnia.Tracking.Collision.CollisionNotifier+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  CollisionChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Tracking.Collision.CollisionNotifier+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  CollisionStopped:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6431296930578707291}
+        m_MethodName: DoExtract
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: Zinnia.Tracking.Collision.CollisionNotifier+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+--- !u!54 &6431296930874057620
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930874057610}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!1 &6431296930920124867
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6431296930920124866}
+  - component: {fileID: 6431296930920124879}
+  - component: {fileID: 6431296930920124876}
+  - component: {fileID: 6431296930920124877}
+  m_Layer: 0
+  m_Name: DefaultCollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6431296930920124866
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930920124867}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6431296930874057621}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6431296930920124879
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930920124867}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6431296930920124876
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930920124867}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!135 &6431296930920124877
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6431296930920124867}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1001 &6431296930904075557
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6431296929051571372}
+    m_Modifications:
+    - target: {fileID: 1068226196861958, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+      propertyPath: m_Name
+      value: ObjectFollower
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068226196861958, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114960550120155566, guid: 9aa99d00578590e45a52faa205a1014a,
+        type: 3}
+      propertyPath: sources.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114960550120155566, guid: 9aa99d00578590e45a52faa205a1014a,
+        type: 3}
+      propertyPath: sources.Array.data[0]
+      value: 
+      objectReference: {fileID: 6431296930386113179}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+--- !u!114 &6402115879936492683 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 114960550120155566, guid: 9aa99d00578590e45a52faa205a1014a,
+    type: 3}
+  m_PrefabInstance: {fileID: 6431296930904075557}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36b5781728bc3ef47af5d7aca57b0e57, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &6435950448995388925 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a,
+    type: 3}
+  m_PrefabInstance: {fileID: 6431296930904075557}
+  m_PrefabAsset: {fileID: 0}

--- a/Prefabs/Interactions/SnapDropZone/SnapDropZone.prefab.meta
+++ b/Prefabs/Interactions/SnapDropZone/SnapDropZone.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 82f26bda69675c54da7d34a2a6839748
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The SnapDropZone prefab allows "snapping" an object to a set
transform target state and specifically comes with support for
interactable object so they can be snapped and unsnapped by
ungrabbing and grabbing respectively. A simple checkbox allows
turning on cloning of the unsnapped object to make the SnapDropZone
act as some kind of instantiation component.