### PR TITLE
Fixed onEnable search through invalid scene

### DIFF
--- a/Assets/VRTK/Source/SDK/Simulator/SDK_InputSimulator.cs
+++ b/Assets/VRTK/Source/SDK/Simulator/SDK_InputSimulator.cs
@@ -1,4 +1,6 @@
-﻿namespace VRTK
+﻿using UnityEngine.SceneManagement;
+
+namespace VRTK
 {
     using UnityEngine;
     using UnityEngine.UI;
@@ -193,25 +195,29 @@
             leftController.selected = false;
             destroyed = false;
 
-            SDK_SimController controllerSDK = VRTK_SDK_Bridge.GetControllerSDK() as SDK_SimController;
-            if (controllerSDK != null)
+            if (SceneManager.GetActiveScene().isLoaded)
             {
-                Dictionary<string, KeyCode> keyMappings = new Dictionary<string, KeyCode>()
+                SDK_SimController controllerSDK = VRTK_SDK_Bridge.GetControllerSDK() as SDK_SimController;
+                if (controllerSDK != null)
                 {
-                    {"Trigger", triggerAlias },
-                    {"Grip", gripAlias },
-                    {"TouchpadPress", touchpadAlias },
-                    {"ButtonOne", buttonOneAlias },
-                    {"ButtonTwo", buttonTwoAlias },
-                    {"StartMenu", startMenuAlias },
-                    {"TouchModifier", touchModifier },
-                    {"HairTouchModifier", hairTouchModifier }
-                };
-                controllerSDK.SetKeyMappings(keyMappings);
+                    Dictionary<string, KeyCode> keyMappings = new Dictionary<string, KeyCode>()
+                    {
+                        {"Trigger", triggerAlias},
+                        {"Grip", gripAlias},
+                        {"TouchpadPress", touchpadAlias},
+                        {"ButtonOne", buttonOneAlias},
+                        {"ButtonTwo", buttonTwoAlias},
+                        {"StartMenu", startMenuAlias},
+                        {"TouchModifier", touchModifier},
+                        {"HairTouchModifier", hairTouchModifier}
+                    };
+                    controllerSDK.SetKeyMappings(keyMappings);
+                }
+
+                rightHand.gameObject.SetActive(true);
+                leftHand.gameObject.SetActive(true);
+                crossHairPanel.SetActive(false);
             }
-            rightHand.gameObject.SetActive(true);
-            leftHand.gameObject.SetActive(true);
-            crossHairPanel.SetActive(false);
         }
 
         protected virtual void OnDestroy()

--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
@@ -1,4 +1,7 @@
 ﻿// SDK Setup|Utilities|90030
+
+using UnityEngine.SceneManagement;
+
 namespace VRTK
 {
     using UnityEngine;
@@ -415,7 +418,10 @@ namespace VRTK
             if (VRTK_SDKManager.ValidInstance() && !VRTK_SDKManager.instance.persistOnLoad)
 #pragma warning restore 618
             {
-                PopulateObjectReferences(false);
+                if (SceneManager.GetActiveScene().isLoaded)
+                {
+                    PopulateObjectReferences(false);
+                }
             }
         }
 


### PR DESCRIPTION
VRTK_SDKSetup.onEnable was searching for the components before the scene finished loading, having a null object and throwing an exception. This was breaking new scenes that were loaded from the editor and Unity tests (all test failed because new scene had an unhandled exception). Checking that the scene has finish loading fixes that exception