### PR TITLE
docs(README.md): change required Unity version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 VRTK aims to make building spatial computing solutions in the [Unity] software fast and easy for beginners as well as experienced developers.
 
-> **Requires** the Unity software version 2018.3 (or above).
+> **Requires** the Unity software version 2018.3.10f1 (or above).
 
 ## Getting Started
 


### PR DESCRIPTION
The required Unity version seems to be at least 2018.3.5 based on
user testing. Earlier versions have issues checking out the copy of
Malimbe and/or Zinnia used inside VRTK as direct and indirect
dependencies. This change states Unity 2018.3.10f1 as the required
version as it is known to definitely work and comes with an
important bugfix for builds using XR functionality.