### PR TITLE
fix(Interactions): allow interactor ungrab on untouched interactable - fixes #1988

### DIFF
--- a/Prefabs/Interactions/Interactors/SharedResources/Scripts/GrabInteractorConfigurator.cs
+++ b/Prefabs/Interactions/Interactors/SharedResources/Scripts/GrabInteractorConfigurator.cs
@@ -194,6 +194,10 @@
             InteractableFacade interactable = GrabbedObjects[0].TryGetComponent<InteractableFacade>(true, true);
             if (interactable.IsGrabTypeToggle)
             {
+                if (StartGrabbingPublisher.Payload.ActiveCollisions.Count == 0)
+                {
+                    StartGrabbingPublisher.SetActiveCollisions(CreateActiveCollisionsEventData(interactable.gameObject, null, null));
+                }
                 ProcessGrabAction(StartGrabbingPublisher, true);
             }
             ProcessGrabAction(StopGrabbingPublisher, false);


### PR DESCRIPTION
If the Interactable was grabbed with a toggle grab type then the
Interactor was no longer colliding with the Interactable (but still
grabbing) then the Interactor Grab publisher would be empty and when
the force ungrab was called it would attempt to do a grab before
ungrabbing to ensure the toggle state was set correctly.

However, it would not be able to perform the grab as the touched state
did not exist to populate the grab publisher.

This fix ensures that if the grab publisher payload is empty then it
forces the current interactable into the payload so the initial
grab before ungrabbing can take place.