### PR TITLE
fix(Interactions): call only drive setup to manage property changes

### DIFF
--- a/Prefabs/Interactions/Controllables/SharedResources/Scripts/DirectionalDriveFacade.cs
+++ b/Prefabs/Interactions/Controllables/SharedResources/Scripts/DirectionalDriveFacade.cs
@@ -48,7 +48,7 @@
         [CalledAfterChangeOf(nameof(DriveLimit))]
         protected virtual void OnAfterDriveLimitChange()
         {
-            Drive.CalculateDriveLimits(DriveLimit);
+            Drive.SetUp();
         }
     }
 }

--- a/Prefabs/Interactions/Controllables/SharedResources/Scripts/DriveFacade.cs
+++ b/Prefabs/Interactions/Controllables/SharedResources/Scripts/DriveFacade.cs
@@ -180,7 +180,6 @@
         [CalledAfterChangeOf(nameof(DriveAxis))]
         protected virtual void OnAfterDriveAxisChange()
         {
-            CalculateDriveAxis(DriveAxis);
             Drive.SetUp();
         }
 
@@ -190,7 +189,6 @@
         [CalledAfterChangeOf(nameof(MoveToTargetValue))]
         protected virtual void OnAfterMoveToTargetValueChange()
         {
-            ProcessAutoDrive(MoveToTargetValue);
             Drive.SetUp();
         }
 
@@ -200,7 +198,6 @@
         [CalledAfterChangeOf(nameof(TargetValue))]
         protected virtual void OnAfterTargetValueChange()
         {
-            SetTargetValue(TargetValue);
             Drive.SetUp();
         }
 
@@ -210,7 +207,6 @@
         [CalledAfterChangeOf(nameof(DriveSpeed))]
         protected virtual void OnAfterDriveSpeedChange()
         {
-            ProcessDriveSpeed(DriveSpeed, MoveToTargetValue);
             Drive.SetUp();
         }
 

--- a/Prefabs/Interactions/Controllables/SharedResources/Scripts/RotationalDriveFacade.cs
+++ b/Prefabs/Interactions/Controllables/SharedResources/Scripts/RotationalDriveFacade.cs
@@ -64,7 +64,7 @@
         [CalledAfterChangeOf(nameof(HingeLocation))]
         protected virtual void OnAfterHingeLocationChange()
         {
-            Drive.CalculateHingeLocation(HingeLocation);
+            Drive.SetUp();
         }
     }
 }


### PR DESCRIPTION
The Drive Facades now only call the internal `Drive.SetUp()` method
when any property changes occur. Previously, the specific method
on the drive was called and then the `SetUp()` method was called which
made no sense as the `SetUp()` method would call the specific method
again anyway.

The Directional and Rotational Drive Facade `OnAfterChange` methods
didn't even call `SetUp()` so were not correctly setting up the drive
again after property changes. These now just call `SetUp()` the same
as the abstract DriveFacade class.