### PR TITLE
fix(Locomotion): call correct event on location hover deactivation - fixes #2006

### DIFF
--- a/Prefabs/Locomotion/DestinationLocations/SharedResources/Scripts/DestinationLocationConfigurator.cs
+++ b/Prefabs/Locomotion/DestinationLocations/SharedResources/Scripts/DestinationLocationConfigurator.cs
@@ -87,7 +87,7 @@
         /// </summary>
         public virtual void EmitHoverDeactivated()
         {
-            Facade.HoverActivated?.Invoke();
+            Facade.HoverDeactivated?.Invoke();
         }
 
         /// <summary>


### PR DESCRIPTION
The DestinationLocation was calling the HoverActivated event in the
EmitHoverDeactivated method which is wrong. The correct event is
now being called.