### PR TITLE
fix(Pointers): ensure correct order for pointer actions - fixes #2027

### DIFF
--- a/Prefabs/Pointers/SharedResources/Scripts/PointerConfigurator.cs
+++ b/Prefabs/Pointers/SharedResources/Scripts/PointerConfigurator.cs
@@ -126,6 +126,7 @@
         /// </summary>
         public virtual void ConfigureSelectionType()
         {
+            ActivationAction.gameObject.SetActive(false);
             switch (Facade.SelectionMethod)
             {
                 case PointerFacade.SelectionType.SelectOnActivate:
@@ -137,6 +138,9 @@
                     SelectOnDeactivatedAction.gameObject.SetActive(true);
                     break;
             }
+            ConfigureSelectionAction();
+            ConfigureActivationAction();
+            ActivationAction.gameObject.SetActive(true);
         }
 
         /// <summary>
@@ -197,8 +201,6 @@
         {
             ConfigureTargetValidity();
             ConfigureFollowSources();
-            ConfigureSelectionAction();
-            ConfigureActivationAction();
             ConfigureSelectionType();
         }
     }


### PR DESCRIPTION
There was a race condition where the activation action could be
registered before the selection action meaning doing things like
select on release would not work as the activation action was
being called before the selection action so the pointer would be
disabled before it could select anything.

This fix moves around some of the registration logic to ensure
the correct order for actions.