### PR TITLE
chore(FUNDING.yml): add funding information for patreon

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: vrtk


### PR DESCRIPTION
The FUNDING.yml configures the GitHub page to show a link to the Patreon.