### PR TITLE
fix(Interactions): only draw gizmos when drive is selected

### DIFF
--- a/Prefabs/Interactions/Controllables/SharedResources/Scripts/DirectionalDriveFacade.cs
+++ b/Prefabs/Interactions/Controllables/SharedResources/Scripts/DirectionalDriveFacade.cs
@@ -29,7 +29,7 @@
         public Vector3 GizmoCubeSize { get; set; } = Vector3.one * 0.015f;
         #endregion
 
-        protected virtual void OnDrawGizmos()
+        protected virtual void OnDrawGizmosSelected()
         {
             Gizmos.color = Color.yellow;
             Gizmos.matrix = transform.localToWorldMatrix;

--- a/Prefabs/Interactions/Controllables/SharedResources/Scripts/RotationalDriveFacade.cs
+++ b/Prefabs/Interactions/Controllables/SharedResources/Scripts/RotationalDriveFacade.cs
@@ -45,7 +45,7 @@
         public float GizmoSphereRadius { get; set; } = 0.015f;
         #endregion
 
-        protected virtual void OnDrawGizmos()
+        protected virtual void OnDrawGizmosSelected()
         {
             Gizmos.color = Color.yellow;
             Gizmos.matrix = transform.localToWorldMatrix;


### PR DESCRIPTION
The Directional and Rotational Drive Facades have been updated so
the gizmos for the axis data are only drawn when the drive GameObject
is selected in the hierarchy as this increases editor performance and
it is not necessary to draw gizmos all the time.