### PR TITLE
docs(structure): fix spelling mistake and add clearer version number

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -51,6 +51,6 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 
 **The goal of the Code of Conduct is to resolve conflicts in the most harmonious way possible**. We hope that in most cases issues may be resolved through polite discussion and mutual agreement. Bannings and other forceful measures are to be employed only as a last resort. **Do not** post about the issue publicly or try to rally sentiment against a particular individual or group.
 
-## Acknowledgments
+## Acknowledgements
 
 This document was based on the Code of Conduct from the Elixir project.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -11,7 +11,7 @@
 
 * Source of VRTK (Unity Asset Store or GitHub).
 * Version of VRTK (Unity Asset Store/GitHub release number) (GitHub master commit hash).
-* Version of the Unity software (e.g. Unity 2018.3).
+* Version of the Unity software (e.g. Unity 2018.3.10f1).
 * Hardware used (e.g. Vive/Oculus).
 * SDK used (e.g. OpenVR/SteamVR/Oculus Utilities).
 


### PR DESCRIPTION
There was a spelling mistake in the Code Of Conduct and the Issue
Template now has an example of providing a very specific Unity version
number as this is generally important in debugging.