### PR TITLE
fix(Interactions): optionally inherit RB kinematic on follow action - Fixes #2047

### DIFF
--- a/Prefabs/Interactions/Interactables/SharedResources/NestedPrefabs/GrabActions/Interactable.GrabAction.FollowAction.prefab
+++ b/Prefabs/Interactions/Interactables/SharedResources/NestedPrefabs/GrabActions/Interactable.GrabAction.FollowAction.prefab
@@ -1973,6 +1973,7 @@ MonoBehaviour:
   grabOffset: 0
   isKinematicWhenActive: 1
   isKinematicWhenInactive: 0
+  willInheritIsKinematicWhenInactiveFromConsumerRigidbody: 1
   objectFollower: {fileID: 1803858868811045269}
   followTransformModifier: {fileID: 2304878481562678152}
   followRigidbodyModifier: {fileID: 3324176677558867994}

--- a/Prefabs/Interactions/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableFollowAction.cs
+++ b/Prefabs/Interactions/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableFollowAction.cs
@@ -86,6 +86,12 @@
         [Serialized]
         [field: DocumentedByXml]
         public bool IsKinematicWhenInactive { get; set; }
+        /// <summary>
+        /// Whether the <see cref="IsKinematicWhenInactive"/> property inherits the kinematic state from <see cref="GrabSetup.Facade.ConsumerRigidbody.isKinematic"/>.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public bool WillInheritIsKinematicWhenInactiveFromConsumerRigidbody { get; set; } = true;
         #endregion
 
         #region Tracking Settings
@@ -181,7 +187,10 @@
         /// </summary>
         protected virtual void ConfigureFollowTracking()
         {
-            IsKinematicWhenInactive = GrabSetup != null ? GrabSetup.Facade.ConsumerRigidbody.isKinematic : false;
+            if (WillInheritIsKinematicWhenInactiveFromConsumerRigidbody)
+            {
+                IsKinematicWhenInactive = GrabSetup != null ? GrabSetup.Facade.ConsumerRigidbody.isKinematic : false;
+            }
             switch (FollowTracking)
             {
                 case TrackingType.FollowTransform:
@@ -255,6 +264,7 @@
             ObjectFollower.Targets.RunWhenActiveAndEnabled(() => ObjectFollower.Targets.Clear());
             ObjectFollower.Targets.RunWhenActiveAndEnabled(() => ObjectFollower.Targets.Add(GrabSetup.Facade.ConsumerContainer));
             VelocityApplier.Target = GrabSetup.Facade.ConsumerRigidbody != null ? GrabSetup.Facade.ConsumerRigidbody : null;
+            ConfigureFollowTracking();
         }
 
         /// <summary>


### PR DESCRIPTION
The GrabInteractableFollowAction can set the kinematic state of the
consumer rigidbody when the follow action is inactive. This is the
default kinematic state for the rigidbody. Initially this default state
was always whatever the actual consumer rigidbody kinematic state was
initially set to, however there may be times where this inherited
default state may not be required so an additional option has been
added to the GrabInteractableFollowAction to ignore the setting of
the inactive state to that of the consumer rigidbody kinematic state.

This fix is largely based on the work by @JWNJWN but also contains
a fix from @bruno1308 which ensures the `ConfigureFollowTracking`
method is called when the GrabSetup is changed.

Co-authored-by: JWNJWN <jwneicho@gmail.com>