### PR TITLE
chore(deps): bump io.extendreality.vrtk.prefabs from 1.0.5 to 1.0.7

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -17,7 +17,7 @@
     "com.unity.textmeshpro": "1.3.0",
     "com.unity.xr.oculus.standalone": "1.38.3",
     "com.unity.xr.openvr.standalone": "1.0.5",
-    "io.extendreality.vrtk.prefabs": "1.0.5",
+    "io.extendreality.vrtk.prefabs": "1.0.7",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",


### PR DESCRIPTION
Bumps the dependency of VRTK.Prefabs to the latest version of 1.0.7.